### PR TITLE
减少代码冗余

### DIFF
--- a/DesktopClock/Utils/StringUtils.cs
+++ b/DesktopClock/Utils/StringUtils.cs
@@ -4,6 +4,15 @@ namespace DesktopClock.Utils
 {
     public static class StringUtils
     {
+        public static string GetMiddle(this string text, string left, string right)
+        {
+            if (string.IsNullOrEmpty(text)) return text;
+
+            var leftIndex = text.IndexOf(left, StringComparison.Ordinal);
+
+            throw new NotImplementedException();
+        }
+
         public static string GetBetween(string text, string left, string right)
         {
             //判断是否为null或者是empty
@@ -36,9 +45,31 @@ namespace DesktopClock.Utils
             return text.Substring(Lindex, Rindex - Lindex); //返回查找到的文本
         }
 
+        public static string GetLeft(this string text, string findStr)
+        {
+            if (text is null) throw new ArgumentNullException(nameof(text));
+            if (findStr is null) throw new ArgumentNullException(nameof(findStr));
+            if (findStr == string.Empty) return text;
+
+            var textSpan = text.AsSpan();
+            var findSpan = findStr.AsSpan();
+            for (int i = 0, j = 0; i < text.Length; ++i)
+            {
+                while (j < findStr.Length && textSpan[i] == findSpan[j])
+                {
+                    if (j == findStr.Length - 1)
+                    {
+                        return textSpan[..(i - findStr.Length + 1)].ToString();
+                    }
+                    ++j;
+                }
+            }
+            return string.Empty;
+        }
+
         public static string String_GetLeft(string in_str, string find_str)
         {
-            var re_1  = "";
+            var re_1 = "";
             var index = in_str.IndexOf(find_str, StringComparison.Ordinal);
             if (index > 0)
             {
@@ -48,10 +79,32 @@ namespace DesktopClock.Utils
             return re_1;
         }
 
+        public static string GetRight(this string text, string findStr)
+        {
+            if (text is null) throw new ArgumentNullException(nameof(text));
+            if (findStr is null) throw new ArgumentNullException(nameof(findStr));
+            if (findStr == string.Empty) return text;
+
+            var textSpan = text.AsSpan();
+            var findSpan = findStr.AsSpan();
+            for (int i = 0, j = 0; i < text.Length; ++i)
+            {
+                while (j < findStr.Length && textSpan[i] == findSpan[j])
+                {
+                    if (j == findStr.Length - 1)
+                    {
+                        return textSpan[(i + 1)..].ToString();
+                    }
+                    ++j;
+                }
+            }
+            return string.Empty;
+        }
+
         public static string String_GetRight_Last(string in_str, string find_str)
         {
             var sz = in_str.Split(find_str.ToCharArray());
-            var   re = "";
+            var re = "";
             if (true)
             {
                 if (sz.Length > 0)

--- a/DesktopClock/Utils/StringUtils.cs
+++ b/DesktopClock/Utils/StringUtils.cs
@@ -45,28 +45,6 @@ namespace DesktopClock.Utils
             return text.Substring(Lindex, Rindex - Lindex); //返回查找到的文本
         }
 
-        public static string GetLeft(this string text, string findStr)
-        {
-            if (text is null) throw new ArgumentNullException(nameof(text));
-            if (findStr is null) throw new ArgumentNullException(nameof(findStr));
-            if (findStr == string.Empty) return text;
-
-            var textSpan = text.AsSpan();
-            var findSpan = findStr.AsSpan();
-            for (int i = 0, j = 0; i < text.Length; ++i)
-            {
-                while (j < findStr.Length && textSpan[i] == findSpan[j])
-                {
-                    if (j == findStr.Length - 1)
-                    {
-                        return textSpan[..(i - findStr.Length + 1)].ToString();
-                    }
-                    ++j;
-                }
-            }
-            return string.Empty;
-        }
-
         public static string String_GetLeft(string in_str, string find_str)
         {
             var re_1 = "";
@@ -77,28 +55,6 @@ namespace DesktopClock.Utils
             }
 
             return re_1;
-        }
-
-        public static string GetRight(this string text, string findStr)
-        {
-            if (text is null) throw new ArgumentNullException(nameof(text));
-            if (findStr is null) throw new ArgumentNullException(nameof(findStr));
-            if (findStr == string.Empty) return text;
-
-            var textSpan = text.AsSpan();
-            var findSpan = findStr.AsSpan();
-            for (int i = 0, j = 0; i < text.Length; ++i)
-            {
-                while (j < findStr.Length && textSpan[i] == findSpan[j])
-                {
-                    if (j == findStr.Length - 1)
-                    {
-                        return textSpan[(i + 1)..].ToString();
-                    }
-                    ++j;
-                }
-            }
-            return string.Empty;
         }
 
         public static string String_GetRight_Last(string in_str, string find_str)
@@ -115,5 +71,51 @@ namespace DesktopClock.Utils
 
             return re;
         }
+
+        #region 拓展方法
+
+        /// <summary>
+        /// 获取字符串中某个子字符串右侧的字符串
+        /// </summary>
+        /// <param name="text">源字符串</param>
+        /// <param name="findStr">查找的字符串</param>
+        /// <returns>查找字符串右侧的字符串</returns>
+        public static string GetRight(this string text, string findStr)
+        {
+            if (text is null) throw new ArgumentNullException(nameof(text));
+            if (string.IsNullOrEmpty(findStr)) return text;
+
+            var index = text.IndexOf(findStr);
+
+            return index == -1
+                ? string.Empty
+                : text[(index + findStr.Length)..].ToString();
+        }
+
+        public static string GetRightLast(this string text, string findStr)
+        {
+            if (text is null) throw new ArgumentNullException(nameof(text));
+            if (string.IsNullOrEmpty(findStr)) return text;
+
+            var lastIndex = text.LastIndexOf(findStr);
+
+            return lastIndex == -1
+                ? string.Empty
+                : text[(lastIndex + findStr.Length)..].ToString();
+        }
+
+        public static string GetLeft(this string text, string findStr)
+        {
+            if (text is null) throw new ArgumentNullException(nameof(text));
+            if (string.IsNullOrEmpty(findStr)) return text;
+
+            var index = text.IndexOf(findStr);
+
+            return index == -1
+                ? string.Empty
+                : text[..(index + 1)].ToString();
+        }
+
+        #endregion
     }
 }

--- a/DesktopClock/Utils/WeatherUtils.cs
+++ b/DesktopClock/Utils/WeatherUtils.cs
@@ -7,217 +7,129 @@ namespace DesktopClock.Utils
     {
         public class WeatherStatus
         {
-            public string WeatherIco   = "ERROR LOADING WEATHER";
-            public string Temp         = "";
-            public string Wind         = "";
-            public string WindLevel    = "";
-            public Color  WeatherColor = Colors.White;
-            public Color  TempColor    = Colors.White;
-            public Color  WindColor    = Colors.White;
+            public string WeatherIco = "ERROR LOADING WEATHER";
+            public string Temp = "";
+            public string Wind = "";
+            public string WindLevel = "";
+            public Color WeatherColor = Colors.White;
+            public Color TempColor = Colors.White;
+            public Color WindColor = Colors.White;
         }
+
+        private static Color WeatherColorSwitcher(string icon) =>
+            icon switch
+            {
+                "☀️" => Colors.Yellow,
+                "⛅️" => Colors.Orange,
+                "🌦" => Colors.Blue,
+                "⛈️" => Colors.Blue,
+                "🌩" => Colors.Yellow,
+                "☁️" => Colors.Gray,
+                "🌧" => Colors.DarkBlue,
+                "🌁" => Colors.Gray,
+                "🌫" => Colors.White,
+                "❄️" => Colors.White,
+                "🌨" => Colors.White,
+                _ => Colors.White,
+            };
+
+        private static Color TempColorSwitcher(int temp) =>
+            temp switch
+            {
+                _ when temp < -20 => Colors.DarkBlue,
+                _ when temp < -10 => Colors.MidnightBlue,
+                _ when temp < 10 => Colors.Blue,
+                _ when temp < 20 => Colors.DarkTurquoise,
+                _ when temp < 30 => Colors.Aqua,
+                _ when temp < 35 => Colors.Yellow,
+                _ when temp < 40 => Colors.Orange,
+                _ when temp < 50 => Colors.OrangeRed,
+                _ when temp < 60 => Colors.Red,
+                _ => Colors.DarkRed,
+            };
+
+        private static (string, Color) WindConvertor(int wind)
+        {
+
+            var windLevel = ((int)(0.0979 * wind + 0.317 + 0.5)).ToString();
+            var windColor = new Color
+            {
+
+            };
+
+            // FFFFFFFF
+            // FFF0F8FF
+            // FF7FFFD4
+            // FF00FFFF
+            // FF00FFFF
+            // FF00BFFF
+            // FF6495ED
+            // FF1E90FF
+            // FF0000FF
+            // FF0000CD
+            // FF00008B
+            // FF191970
+            // FF000080
+            throw new NotImplementedException();
+        }
+
+
+        private static (string, Color) WindSwitcher(int wind) =>
+            wind switch
+            {
+                _ when wind < 1 => ("0", Colors.White),
+                _ when wind <= 5 => ("1", Colors.AliceBlue),
+                _ when wind <= 19 => ("2", Colors.Aquamarine),
+                _ when wind <= 28 => ("3", Colors.Cyan),
+                _ when wind <= 38 => ("4", Colors.Cyan),
+                _ when wind <= 49 => ("5", Colors.DeepSkyBlue),
+                _ when wind <= 61 => ("6", Colors.CornflowerBlue),
+                _ when wind <= 74 => ("7", Colors.DodgerBlue),
+                _ when wind <= 88 => ("8", Colors.Blue),
+                _ when wind <= 102 => ("9", Colors.MediumBlue),
+                _ when wind <= 117 => ("10", Colors.DarkBlue),
+                _ when wind <= 134 => ("11", Colors.MidnightBlue),
+                _ when wind <= 149 => ("12", Colors.Navy),
+                _ when wind <= 166 => ("13", Colors.Navy),
+                _ when wind <= 183 => ("14", Colors.Navy),
+                _ when wind <= 201 => ("15", Colors.Navy),
+                _ when wind <= 220 => ("16", Colors.Navy),
+                _ => ("17", Colors.Navy)
+            };
+
 
         public static WeatherStatus ParseWeather(string input)
         {
             input = input.Replace("  ", "").Trim();
-            string weatherIco    = StringUtils.String_GetLeft(input, "🌡").Trim();
-            string Temp          = StringUtils.GetBetween(input, "🌡", "🌬").Trim();
-            string Wind          = StringUtils.String_GetRight_Last(input, "🌬").Trim();
-            string WindDirection = "";
+
+            var weatherIco = StringUtils.String_GetLeft(input, "🌡").Trim();
+            var tempInput = StringUtils.GetBetween(input, "🌡", "🌬").Trim();
+            var windInput = StringUtils.String_GetRight_Last(input, "🌬").Trim();
+            var windDirection = "";
+
             //Emoji双字符，会遗留一个空白字符，需根据第二个字符是否为风向来判断
-            if (!Char.IsDigit(Wind.ToCharArray()[1])) //如果不是数字，那就是风向了
+
+            if (!char.IsDigit(windInput.ToCharArray()[1])) //如果不是数字，那就是风向了
             {
-                WindDirection = Wind.Substring(1, 1); //风向
-                Wind          = Wind.Substring(2);    //去掉风向之后的风速
+                windDirection = windInput.Substring(1, 1); //风向
+                windInput = windInput[2..];    //去掉风向之后的风速
             }
 
-            var re = new WeatherStatus();
-            re.WeatherIco = weatherIco + " ";
-            switch (weatherIco)
-            {
-                case "☀️":
-                    re.WeatherColor = Colors.Yellow;
-                    break;
-                case "⛅️":
-                    re.WeatherColor = Colors.Orange;
-                    break;
-                case "🌦":
-                    re.WeatherColor = Colors.Blue;
-                    break;
-                case "⛈️":
-                    re.WeatherColor = Colors.Blue;
-                    break;
-                case "🌩":
-                    re.WeatherColor = Colors.Yellow;
-                    break;
-                case "☁️":
-                    re.WeatherColor = Colors.Gray;
-                    break;
-                case "🌧":
-                    re.WeatherColor = Colors.DarkBlue;
-                    break;
-                case "🌁":
-                    re.WeatherColor = Colors.Gray;
-                    break;
-                case "🌫":
-                    re.WeatherColor = Colors.White;
-                    break;
-                case "❄️":
-                    re.WeatherColor = Colors.White;
-                    break;
-                case "🌨":
-                    re.WeatherColor = Colors.White;
-                    break;
-                default:
-                    re.WeatherColor = Colors.White;
-                    break;
-            }
+            _ = int.TryParse(StringUtils.String_GetLeft(tempInput[1..], "°C"), out int temp);
+            _ = int.TryParse(StringUtils.String_GetLeft(windInput, "km/h"), out var wind);
 
-            re.Temp = "🌡" + Temp + " ";       //SubString从第二个取的原因是Emoji字符会遗留一个空白字符
-            if (!int.TryParse(StringUtils.String_GetLeft(Temp.Substring(1), "°C"), out int temp))
+            var ret = new WeatherStatus
             {
-                temp = 0;
-            }
+                WeatherIco = weatherIco + " ",
+                WeatherColor = WeatherColorSwitcher(weatherIco),
+                Temp = "🌡" + tempInput + " ",      //SubString从第二个取的原因是Emoji字符会遗留一个空白字符
+                TempColor = TempColorSwitcher(temp),
+                Wind = "💨" + windDirection + windInput + " ",
+            };
 
-            if (temp < -20)
-            {
-                re.TempColor = Colors.DarkBlue;
-            }
+            (ret.WindLevel, ret.WindColor) = WindSwitcher(wind);
 
-            if (temp < -10)
-            {
-                re.TempColor = Colors.MidnightBlue;
-            }
-            else if (temp < 10)
-            {
-                re.TempColor = Colors.Blue;
-            }
-            else if (temp < 20)
-            {
-                re.TempColor = Colors.DarkTurquoise;
-            }
-            else if (temp < 30)
-            {
-                re.TempColor = Colors.Aqua;
-            }
-            else if (temp < 35)
-            {
-                re.TempColor = Colors.Yellow;
-            }
-            else if (temp < 40)
-            {
-                re.TempColor = Colors.Orange;
-            }
-            else if (temp < 50)
-            {
-                re.TempColor = Colors.OrangeRed;
-            }
-            else if (temp < 60)
-            {
-                re.TempColor = Colors.Red;
-            }
-            else
-            {
-                re.TempColor = Colors.DarkRed;
-            }
-
-            re.Wind = "💨" + WindDirection + Wind + " ";
-            if (!int.TryParse(StringUtils.String_GetLeft(Wind, "km/h"), out int wind))
-            {
-                wind = 0;
-            }
-
-            if(wind <1 )
-            {
-                re.WindLevel = "0";
-                re.WindColor = Colors.White;
-            }
-            else if (wind <= 5)
-            {
-                re.WindLevel = "1";
-                re.WindColor = Colors.AliceBlue;
-            }
-            else if (wind <= 19)
-            {
-                re.WindLevel = "2";
-                re.WindColor = Colors.Aquamarine;
-            }
-            else if (wind <= 28)
-            {
-                re.WindLevel = "3";
-                re.WindColor = Colors.Aqua;
-            }
-            else if (wind <= 38)
-            {
-                re.WindLevel = "4";
-                re.WindColor = Colors.Cyan;
-            }
-            else if (wind <= 49)
-            {
-                re.WindLevel = "5";
-                re.WindColor = Colors.DeepSkyBlue;
-            }
-            else if (wind <= 61)
-            {
-                re.WindLevel = "6";
-                re.WindColor = Colors.CornflowerBlue;
-            }
-            else if (wind <= 74)
-            {
-                re.WindLevel = "7";
-                re.WindColor = Colors.DodgerBlue;
-            }
-            else if (wind <= 88)
-            {
-                re.WindLevel = "8";
-                re.WindColor = Colors.Blue;
-            }
-            else if (wind <= 102)
-            {
-                re.WindLevel = "9";
-                re.WindColor = Colors.MediumBlue;
-            }
-            else if (wind <= 117)
-            {
-                re.WindLevel = "10";
-                re.WindColor = Colors.DarkBlue;
-            }
-            else if (wind <= 134)
-            {
-                re.WindLevel = "11";
-                re.WindColor = Colors.MidnightBlue;
-            }
-            else if (wind <= 149)
-            {
-                re.WindLevel = "12";
-                re.WindColor = Colors.Navy;
-            }
-            else if (wind <= 166)
-            {
-                re.WindLevel = "13";
-                re.WindColor = Colors.Navy;
-            }
-            else if (wind <= 183)
-            {
-                re.WindLevel = "14";
-                re.WindColor = Colors.Navy;
-            }
-            else if (wind <= 201)
-            {
-                re.WindLevel = "15";
-                re.WindColor = Colors.Navy;
-            }
-            else if (wind <= 220)
-            {
-                re.WindLevel = "16";
-                re.WindColor = Colors.Navy;
-            }
-            else
-            {
-                re.WindLevel = "17";
-                re.WindColor = Colors.Navy;
-            }
-
-            return re;
+            return ret;
         }
     }
 }

--- a/DesktopClock/Utils/WeatherUtils.cs
+++ b/DesktopClock/Utils/WeatherUtils.cs
@@ -7,13 +7,13 @@ namespace DesktopClock.Utils
     {
         public class WeatherStatus
         {
-            public string WeatherIco = "ERROR LOADING WEATHER";
-            public string Temp = "";
-            public string Wind = "";
-            public string WindLevel = "";
-            public Color WeatherColor = Colors.White;
-            public Color TempColor = Colors.White;
-            public Color WindColor = Colors.White;
+            public string WeatherIco   = "ERROR LOADING WEATHER";
+            public string Temp         = "";
+            public string Wind         = "";
+            public string WindLevel    = "";
+            public Color  WeatherColor = Colors.White;
+            public Color  TempColor    = Colors.White;
+            public Color  WindColor    = Colors.White;
         }
 
         private static Color WeatherColorSwitcher(string icon) =>

--- a/DesktopClock/Utils/WindowsUtils.cs
+++ b/DesktopClock/Utils/WindowsUtils.cs
@@ -11,6 +11,19 @@ namespace DesktopClock.Utils
                        ?.GetValue("AppsUseLightTheme")
                        ?.ToString();
 
+        public static System.Windows.Media.Color ToColor(this string hex)
+        {
+            var color = ColorTranslator.FromHtml(hex);
+            var toColor = new System.Windows.Media.Color
+            {
+                R = color.R,
+                G = color.G,
+                B = color.B,
+                A = color.A
+            };
+            return toColor;
+        }
+
         public static System.Windows.Media.Color GetColorFromHex(string hex)
         {
             var color   = ColorTranslator.FromHtml(hex);

--- a/DesktopClock/ViewModels/MainWindowViewModel.cs
+++ b/DesktopClock/ViewModels/MainWindowViewModel.cs
@@ -154,45 +154,42 @@ namespace DesktopClock.ViewModels
                         mainWindow.Dispatcher.Invoke(() =>
                                                      {
                                                          mainWindow.tHour_.Foreground =
-                                                             new SolidColorBrush(WindowsUtils
-                                                                 .GetColorFromHex("#36BBCE"));
+                                                             new SolidColorBrush("#36BBCE".ToColor());
                                                          mainWindow.tMinute.Foreground =
-                                                             new SolidColorBrush(WindowsUtils
-                                                                 .GetColorFromHex("#33CCCC"));
+                                                             new SolidColorBrush("#33CCCC".ToColor());
                                                          mainWindow.tSecond.Foreground =
-                                                             new SolidColorBrush(WindowsUtils
-                                                                 .GetColorFromHex("#5CCCCC"));
+                                                             new SolidColorBrush("#5CCCCC".ToColor());
                                                          mainWindow.tDate.Foreground =
                                                              new
-                                                                 LinearGradientBrush(WindowsUtils.GetColorFromHex("#BF7130"),
-                                                                     WindowsUtils.GetColorFromHex("#FF7400"),
+                                                                 LinearGradientBrush("#BF7130".ToColor(),
+                                                                    "#FF7400".ToColor(),
                                                                      45.0);
                                                          mainWindow.tDay.Foreground =
                                                              new
-                                                                 LinearGradientBrush(WindowsUtils.GetColorFromHex("#FF7400"),
-                                                                     WindowsUtils.GetColorFromHex("#FFB273"),
+                                                                 LinearGradientBrush("#FF7400".ToColor(),
+                                                                     "#FFB273".ToColor(),
                                                                      45.0);
                                                          mainWindow.HourMinuteDot.Foreground =
                                                              new
-                                                                 LinearGradientBrush(WindowsUtils.GetColorFromHex("#009999"),
-                                                                     WindowsUtils.GetColorFromHex("#33CCCC"),
+                                                                 LinearGradientBrush("#009999".ToColor(),
+                                                                     "#33CCCC".ToColor(),
                                                                      45.0);
                                                          mainWindow.MinuteSecondDot.Foreground =
                                                              new
-                                                                 LinearGradientBrush(WindowsUtils.GetColorFromHex("#33CCCC"),
-                                                                     WindowsUtils.GetColorFromHex("#5CCCCC"),
+                                                                 LinearGradientBrush("#33CCCC".ToColor(),
+                                                                     "#5CCCCC".ToColor(),
                                                                      45.0);
                                                      });
                         break;
                     case "0":
                         mainWindow.Dispatcher.Invoke(() =>
                                                      {
-                                                         Color color1 = WindowsUtils.GetColorFromHex("#057D9F");
-                                                         Color color2 = WindowsUtils.GetColorFromHex("#39AECF");
-                                                         Color color3 = WindowsUtils.GetColorFromHex("#61B7CF");
-                                                         Color color4 = WindowsUtils.GetColorFromHex("#5DC8CD");
-                                                         Color color5 = WindowsUtils.GetColorFromHex("#3F92D2");
-                                                         Color color6 = WindowsUtils.GetColorFromHex("#0B61A4");
+                                                         var color1 = "#057D9F".ToColor();
+                                                         var color2 = "#39AECF".ToColor();
+                                                         var color3 = "#61B7CF".ToColor();
+                                                         var color4 = "#5DC8CD".ToColor();
+                                                         var color5 = "#3F92D2".ToColor();
+                                                         var color6 = "#0B61A4".ToColor();
 
 
                                                          mainWindow.tHour_.Foreground =
@@ -208,13 +205,13 @@ namespace DesktopClock.ViewModels
 
                                                          mainWindow.tDate.Foreground =
                                                              new
-                                                                 LinearGradientBrush(WindowsUtils.GetColorFromHex("#1049A9"),
-                                                                     WindowsUtils.GetColorFromHex("#87baf3"),
+                                                                 LinearGradientBrush("#1049A9".ToColor(),
+                                                                     "#87baf3".ToColor(),
                                                                      45.0);
                                                          mainWindow.tDay.Foreground =
                                                              new
-                                                                 LinearGradientBrush(WindowsUtils.GetColorFromHex("#87baf3"),
-                                                                     WindowsUtils.GetColorFromHex("#052C6E"),
+                                                                 LinearGradientBrush("#87baf3".ToColor(),
+                                                                     "#052C6E".ToColor(),
                                                                      45.0);
                                                      });
                         break;


### PR DESCRIPTION
1. 将 `WeatherUtils` 中合适的switch-case替换为switch-case表达式，使用奇怪的switch-case替换大块if-else（有计划计算RGB来代替原来的数值指定颜色）；将长的switch-case单独拆分为方法。
2. 在 `StringUtils` 中添加了一些 `string` 的拓展方法，计划取代其中的静态方法。
3. 在 `WindowsUtils` 中添加 `string` 的拓展方法 `ToColor`，用于将hex转成 `Color` 类（但是我突然觉得这样有点不合理）。